### PR TITLE
Guard hunter prompt for the hunter role

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -154,10 +154,10 @@ class _HomeRouter extends ConsumerWidget {
     }
 
     // Si le serveur nous envoie une liste de cibles pour le tir du chasseur,
-    // afficher immédiatement l'écran dédié. On se base uniquement sur la
-    // présence de `hunterTargets` pour être robuste aux cas où le rôle local
-    // n'est pas encore resynchronisé (reconnexion, snapshot tardif, etc.).
-    if (s.hunterTargets.isNotEmpty) {
+    // afficher immédiatement l'écran dédié, même si l'on est déjà mort.
+    // On vérifie explicitement que le rôle courant est bien HUNTER pour ne
+    // pas afficher cet écran à un joueur mal synchronisé.
+    if (youRole == Role.HUNTER && s.hunterTargets.isNotEmpty) {
       return const HunterScreen();
     }
 

--- a/lib/views/dead_screen.dart
+++ b/lib/views/dead_screen.dart
@@ -31,9 +31,10 @@ class _DeadScreenState extends ConsumerState<DeadScreen> {
     // Lorsqu’il meurt, il peut tirer une dernière balle. Cet « éveil » arrive
     // pendant la phase MORNING via l’événement serveur hunter:wake.
     // Pour éviter que le joueur quitte avant d’exercer ce pouvoir, on masque
-    // temporairement le bouton « Quitter » tant qu'une cible est proposée
-    // (hunterTargets non vide).
-    final bool hasPendingHunterShot = s.hunterTargets.isNotEmpty;
+    // temporairement le bouton « Quitter » tant qu'une cible est proposée au
+    // chasseur local (rôle HUNTER et hunterTargets non vide).
+    final bool hasPendingHunterShot =
+        s.role == Role.HUNTER && s.hunterTargets.isNotEmpty;
     if (hasPendingHunterShot) {
       return const HunterScreen();
     }


### PR DESCRIPTION
## Summary
- guard the home router hunter prompt behind the hunter role before falling back to death handling
- ensure the dead screen only redirects to the hunter UI for an actual hunter with pending targets

## Testing
- npm run test:nocov

------
https://chatgpt.com/codex/tasks/task_b_68d02518e2f0832ea985f35cbf87a664